### PR TITLE
account for possibility of null in p22.FSM.list and fix plot title

### DIFF
--- a/utilities/report_qc/SQANTI3_report.Rmd
+++ b/utilities/report_qc/SQANTI3_report.Rmd
@@ -683,18 +683,31 @@ cat ('\n###', "Distance to Annotated Transcription Start Site {.tabset .tabset-f
 ```{r p22.FSM.list, eval = exists("p22.FSM.list") && length(p22.FSM.list)}
 if(length(p22.FSM.list)>0) {
   p22.stitles.FSM<-list("Alternative 3'End for FSM",
-                      "Alternative 3'5'End for FSM",
-                      "Alternative 5'End for FSM",
-                      "Reference Match for FSM")
+                        "Alternative 3'5'End for FSM",
+                        "Alternative 5'End for FSM",
+                        "Reference Match for FSM")
   for (i in 1:length(p22.FSM.list)) {
     cat ('\n####', p22.stitles.FSM[[i]][1], '\n')
-    print(htmltools::tagList(ggplotly(p22.FSM.list[[i]])) %>%
-            layout(width=800, margin = list(r = 150), 
-                   title = list(text = paste0("Distance to Annotated Transcription Start Site for ISM", '<br>', p22.stitles.FSM[[i]][1],'<br>','<sup>', 'Negative values indicate downstream of annotated TSS','</sup>')))
+    if (!is.null(p22.FSM.list[[i]])) {
+      print(htmltools::tagList(
+        ggplotly(p22.FSM.list[[i]]) %>%
+          layout(
+            width = 800,
+            margin = list(r = 150),
+            title = list(text = paste0("Distance to Annotated Transcription Start Site for FSM", '<br>', p22.stitles.FSM[[i]][1],'<br>','<sup>', 'Negative values indicate downstream of annotated TSS','</sup>'))
           )
-    print(htmltools::tagList(ggplotly(p22.FSM.list.a[[i]])%>%
-            layout(width=800, margin = list(r = 150),
-                    title = list(text = paste0("Distance to Annotated Transcription Start Site for ISM", '<br>', p22.stitles.FSM[[i]][1],'<br>','<sup>', 'Negative values indicate downstream of annotated TSS','</sup>')))))
+      ))
+    }
+    if (!is.null(p22.FSM.list.a[[i]])) {
+      print(htmltools::tagList(
+        ggplotly(p22.FSM.list.a[[i]]) %>%
+          layout(
+            width = 800,
+            margin = list(r = 150),
+            title = list(text = paste0("Distance to Annotated Transcription Start Site for FSM", '<br>', p22.stitles.FSM[[i]][1],'<br>','<sup>', 'Negative values indicate downstream of annotated TSS','</sup>'))
+          )
+      ))
+    }
     
   }
 }


### PR DESCRIPTION
This fixes an error in generating the HTML report for SQANTI3 QC, as spotted by my labmates @mpmargolis and @shr4vya:

```
Quitting from lines 684-701 [p22.FSM.list] (SQANTI3_report.Rmd)
Error in `h()`:
! error in evaluating the argument 'x' in selecting a method for function 'print': no applicable method for 'layout' applied to an object of class "shiny.tag"
Backtrace:
 1. base::print(...)
 6. base::.handleSimpleError(...)
 7. base (local) h(simpleError(msg, call))
```

The error only occurs when the input classification file to the report script contains no instances of one of the FSM subcategories: alternative_3end, alternative_3end5end, alternative_5end, or reference_match (which we noticed when running SQANTI3 on GTFs from [IsoQuant](https://github.com/ablab/IsoQuant) and [bambu](https://github.com/GoekeLab/bambu)). This results in a null value in `p22.FSM.list` that must be checked for. There was also a typo in the title for these particular plots, identifying FSMs as ISMs.