### PR TITLE
problem when using +4 SR files solved

### DIFF
--- a/utilities/short_reads.py
+++ b/utilities/short_reads.py
@@ -183,11 +183,13 @@ def get_ratio_TSS(inside_bed, outside_bed, replicates, chr_order):
         if b == 0 :
             ratio_rep_df = merged['id']
         ratio_rep_df = pandas.merge(ratio_rep_df, merged[['id','ratio_TSS']], on='id')
+        renamed_ratioTSS = "ratio_TSS_" + str(b)
+        ratio_rep_df = ratio_rep_df.rename(columns={'ratio_TSS':renamed_ratioTSS})
+
     #ratio_rep_df.to_csv(out_TSS_file, index=False)
     ratio_rep_df['max_ratio_TSS']=ratio_rep_df.max(axis=1, numeric_only=True)
     ratio_rep_df = ratio_rep_df[['id','max_ratio_TSS']]
     ratio_rep_dict = ratio_rep_df.set_index('id').T.to_dict()
     os.system('rm {i} {o}'.format(i=inside_bed, o=outside_bed))
     print('Temp files removed.\n')
-    return(ratio_rep_dict)
-
+    return(ratio_rep_dict) 


### PR DESCRIPTION
This modification renames the the 'ratio_TSS' column of the dataframe, this should allow us to use 4 or more SR files.