### PR TITLE
Correction of the classfication of mono-exons

### DIFF
--- a/sqanti3_qc.py
+++ b/sqanti3_qc.py
@@ -1238,19 +1238,20 @@ def transcriptsKnownSpliceSites(isoform_hits_name, refs_1exon_by_chr, refs_exons
                 # if we haven't exited here, then ISM hit is not found yet
                 # instead check if it's NIC by intron retention
                 # but we don't exit here since the next gene could be a ISM hit
-                if ref.txStart <= trec.txStart < trec.txEnd <= ref.txEnd:
-                    isoform_hit.str_class = "genic"
-                    isoform_hit.subtype = "mono-exon"
-                    # check for intron retention
-                    if len(ref.junctions) > 0:
-                        for (d,a) in ref.junctions:
-                            if trec.txStart < d < a < trec.txEnd:
-                                isoform_hit.str_class = "novel_in_catalog"
-                                isoform_hit.subtype = "mono-exon_by_intron_retention"
-                                break
-                    isoform_hit.modify("novel", ref.gene, 'NA', 'NA', ref.length, ref.exonCount)
-                    get_gene_diff_tss_tts(isoform_hit)
-                    return isoform_hit
+                #if ref.txStart <= trec.txStart < trec.txEnd <= ref.txEnd:
+                # isoform_hit.str_class = "genic"
+                # isoform_hit.subtype = "mono-exon"
+                # check for intron retention
+                if len(ref.junctions) > 0:
+                    for (d,a) in ref.junctions:
+                        if trec.txStart < d < a < trec.txEnd:
+                            isoform_hit.str_class = "novel_in_catalog"
+                            isoform_hit.subtype = "mono-exon_by_intron_retention"
+                            
+                            isoform_hit.modify("novel", ref.gene, 'NA', 'NA', ref.length, ref.exonCount)
+                            get_gene_diff_tss_tts(isoform_hit)
+
+                            return isoform_hit
 
                 # if we get to here, means neither ISM nor NIC, so just add a ref gene and categorize further later
                 isoform_hit.genes.append(ref.gene)

--- a/sqanti3_qc.py
+++ b/sqanti3_qc.py
@@ -1239,12 +1239,13 @@ def transcriptsKnownSpliceSites(isoform_hits_name, refs_1exon_by_chr, refs_exons
                 # instead check if it's NIC by intron retention
                 # but we don't exit here since the next gene could be a ISM hit
                 if ref.txStart <= trec.txStart < trec.txEnd <= ref.txEnd:
-                    isoform_hit.str_class = "novel_in_catalog"
+                    isoform_hit.str_class = "genic"
                     isoform_hit.subtype = "mono-exon"
                     # check for intron retention
                     if len(ref.junctions) > 0:
                         for (d,a) in ref.junctions:
                             if trec.txStart < d < a < trec.txEnd:
+                                isoform_hit.str_class = "novel_in_catalog"
                                 isoform_hit.subtype = "mono-exon_by_intron_retention"
                                 break
                     isoform_hit.modify("novel", ref.gene, 'NA', 'NA', ref.length, ref.exonCount)


### PR DESCRIPTION
Previously, mono-exons, not classified as FSM or ISM, and contained inside a transcript, were classified as NIC. Now, only those mono-exons spaning a whole intron of the transcript are considered NIC (by intron retention), otherwise, they are considered genic.  On the other hand, mono-exons starting before the beginning or ending after the end of the reference transcript were classified as genic, even if they span a whole intron. Now, these transcripts that start/finish before/after the reference transcript and span a whole intron are classified as NIC.

While doing this I found a bug in the classification of ISM mono-exons (probably affecting a very limited number of transcripts). This has also been fixed.

