### PR TITLE
Match `sqanti3_filter.py`'s no output prefix behavior in `sqanti3_rescue.py`

### DIFF
--- a/sqanti3_rescue.py
+++ b/sqanti3_rescue.py
@@ -531,7 +531,7 @@ def main():
           os.makedirs(args.dir)
   
   if args.output is None:
-      args.output=args.sqanti_filter_classif[args.sqanti_filter_classif.rfind("/")+1:args.sqanti_filter_classif("_classification.txt")]
+      args.output=args.sqanti_filter_classif[args.sqanti_filter_classif.rfind("/")+1:args.sqanti_filter_classif.rfind("_classification.txt")]
       print("Output name not defined. All the outputs will have the prefix {0}".format(args.output), file=sys.stderr)
   
   ## Check that ML-specific args are valid


### PR DESCRIPTION
In `sqanti3_rescue.py` there is a `TypeError` when running with no `-o` set. This PR should fix that by matching the behavior in `sqanti3_filter.py`, shown below.

https://github.com/ConesaLab/SQANTI3/blob/3733cbf60787701b62dce5e943939f78ae329579/sqanti3_filter.py#L224