### PR TITLE
Optionally ignore errors

### DIFF
--- a/sqanti3_qc.py
+++ b/sqanti3_qc.py
@@ -2107,7 +2107,7 @@ def run(args):
     ## Generating report
     if args.report != 'skip':
         print("**** Generating SQANTI3 report....", file=sys.stderr)
-        cmd = RSCRIPTPATH + " {d}/{f} {c} {j} {p} {d} {a} {b}".format(d=utilitiesPath, f=RSCRIPT_REPORT, c=outputClassPath, j=outputJuncPath, p=args.doc, a=args.saturation, b=args.report)
+        cmd = RSCRIPTPATH + " {d}/{f} {c} {j} {p} {d} {a} {b} {i}".format(d=utilitiesPath, f=RSCRIPT_REPORT, c=outputClassPath, j=outputJuncPath, p=args.doc, a=args.saturation, b=args.report, i=args.ignore_report_errors)
         if subprocess.check_call(cmd, shell=True)!=0:
             print("ERROR running command: {0}".format(cmd), file=sys.stderr)
             sys.exit(-1)
@@ -2384,7 +2384,7 @@ def combine_split_runs(args, split_dirs):
 
     if args.report != 'skip':
         print("**** Generating SQANTI3 report....", file=sys.stderr)
-        cmd = RSCRIPTPATH + " {d}/{f} {c} {j} {p} {d} {a} {b}".format(d=utilitiesPath, f=RSCRIPT_REPORT, c=outputClassPath, j=outputJuncPath, p=args.doc, a=args.saturation, b=args.report)
+        cmd = RSCRIPTPATH + " {d}/{f} {c} {j} {p} {d} {a} {b} {i}".format(d=utilitiesPath, f=RSCRIPT_REPORT, c=outputClassPath, j=outputJuncPath, p=args.doc, a=args.saturation, b=args.report, i=args.ignore_report_errors)
         if subprocess.check_call(cmd, shell=True)!=0:
             print("ERROR running command: {0}".format(cmd), file=sys.stderr)
             sys.exit(-1)
@@ -2423,6 +2423,7 @@ def main():
     parser.add_argument("-v", "--version", help="Display program version number.", action='version', version='SQANTI3 '+str(__version__))
     parser.add_argument("--saturation", action="store_true", default=False, help='\t\tInclude saturation curves into report')
     parser.add_argument("--report", choices=['html', 'pdf', 'both', 'skip'], default='html', help='\t\tselect report format\t\t--html\t\t--pdf\t\t--both\t\t--skip')
+    parser.add_argument("--ignore-report-errors", action="store_true", help='\t\tignore errors during the rendering of of the report')
     parser.add_argument('--isoAnnotLite' , help='\t\tRun isoAnnot Lite to output a tappAS-compatible gff3 file',required=False, action='store_true' , default=False)
     parser.add_argument('--gff3' , help='\t\tPrecomputed tappAS species specific GFF3 file. It will serve as reference to transfer functional attributes',required=False)
     parser.add_argument('--short_reads', help='\t\tFile Of File Names (fofn, space separated) with paths to FASTA or FASTQ from Short-Read RNA-Seq. If expression or coverage files are not provided, Kallisto (just for pair-end data) and STAR, respectively, will be run to calculate them.', required=False)

--- a/utilities/report_qc/SQANTI3_report.R
+++ b/utilities/report_qc/SQANTI3_report.R
@@ -15,6 +15,11 @@ junc.file <- args[2]
 utilities.path <- args[4]
 saturation.curves <- args[5]
 report.format <- args[6]
+ignore.errors <- args[7] == "True"
+
+if (ignore.errors) {
+  options(error = function(){})
+}
 
 if (length(args) < 6) {
   stop("Incorrect number of arguments! Script usage is: [classification file] [junction file] [utilities directory path] [True/False for saturation curves] [pdf|html|both]. Abort!")

--- a/utilities/report_qc/SQANTI3_report.R
+++ b/utilities/report_qc/SQANTI3_report.R
@@ -15,14 +15,10 @@ junc.file <- args[2]
 utilities.path <- args[4]
 saturation.curves <- args[5]
 report.format <- args[6]
-ignore.errors <- args[7] == "True"
+ignore.errors <- args[7]
 
-if (ignore.errors) {
-  options(error = function(){})
-}
-
-if (length(args) < 6) {
-  stop("Incorrect number of arguments! Script usage is: [classification file] [junction file] [utilities directory path] [True/False for saturation curves] [pdf|html|both]. Abort!")
+if (length(args) != 7) {
+  stop("Incorrect number of arguments! Script usage is: [classification file] [junction file] [utilities directory path] [True/False for saturation curves] [pdf|html|both] [True/False to ignore errors]. Abort!")
 }
 
 if (!(saturation.curves %in% c('True', 'False'))) {
@@ -31,6 +27,14 @@ if (!(saturation.curves %in% c('True', 'False'))) {
 
 if (!(report.format %in% c('pdf', 'html', 'both'))) {
   stop("Report format needs to be: pdf, html, or both. Abort!")
+}
+
+if (!(ignore.errors %in% c('True', 'False'))) {
+  stop("Ignore errors needs to be 'True' or 'False'. Abort!")
+}
+
+if (ignore.errors == "True") {
+  options(error = function(){})
 }
 
 source(paste(utilities.path, "/report_qc/generatePDFreport.R", sep = "/"))

--- a/utilities/report_qc/SQANTI3_report.Rmd
+++ b/utilities/report_qc/SQANTI3_report.Rmd
@@ -28,7 +28,7 @@ The code contains several parts:
 <!---Basic setting-->
 
 ```{r setup, include=FALSE}
-knitr::opts_chunk$set(echo = TRUE, cache = FALSE, warning = FALSE, results = 'asis', echo=FALSE)
+knitr::opts_chunk$set(cache = FALSE, warning = FALSE, results = 'asis', echo = FALSE, error = ignore.errors)
 
 has_data <- function(df) {
   if (!is.null(df) && length(df) > 0 && is.data.frame(df) && nrow(df) > 0) {


### PR DESCRIPTION
Suggesting this as a quick fix for issues that arise during report generation. Examples can be found here:

#309 
#295 
#221 
#219 

This adds a flag `--ignore-report-errors` to the qc python script which sets `knitr::opts_chunk$set(error = TRUE)` Rmd for the html report and sets `options(error = function() {})` for the process in general.