### PR TITLE
Added compatibility for .gz compressed fasta/fastq isoforms to SQANTI3_QC

### DIFF
--- a/sqanti3_qc.py
+++ b/sqanti3_qc.py
@@ -2159,7 +2159,7 @@ def rename_isoform_seqids(input_fasta, force_id_ignore=False):
     open_function = gzip.open if input_fasta.endswith('.gz') else open
     with open_function(input_fasta, mode="rt") as h:
         if h.readline().startswith('@'): type = 'fastq'
-    f = open_function(input_fasta[:input_fasta.rfind('.')]+'.renamed.fasta', mode='wt')
+    f = open(input_fasta[:input_fasta.rfind('.')]+'.renamed.fasta', mode='wt')
     for r in SeqIO.parse(open_function(input_fasta, "rt"), type):
         m1 = seqid_rex1.match(r.id)
         m2 = seqid_rex2.match(r.id)

--- a/sqanti3_qc.py
+++ b/sqanti3_qc.py
@@ -519,13 +519,7 @@ def correctionPlusORFpred(args, genome_dict):
             print("Skipping aligning of sequences because GTF file was provided.", file=sys.stdout)
 
             ind = 0
-            # gzip.open and open have different default open modes:
-            # gzip.open uses "rb" (read in binary format)
-            # open uses "rt" (read in text format)
-            # This can be solved by making explicit read text mode
-            # as they share this parameter
-            open_function = gzip.open if args.isoforms.endswith('.gz') else open
-            with open_function(args.isoforms, mode='rt') as isoforms_gtf:
+            with open(args.isoforms) as isoforms_gtf:
                 for line in isoforms_gtf:
                     if line[0] != "#" and len(line.split("\t"))!=9:
                         sys.stderr.write("\nERROR: input isoforms file with not GTF format.\n")


### PR DESCRIPTION
Added support to also use gz compressed fastq files as isoforms input file when used as isoforms files in sqanti3_qc, and not just plain fasta.

This adds the feature requested in #312 