### PR TITLE
Add NA replacement value for ratio_TSS column in ML Rescue

### DIFF
--- a/utilities/rescue/run_randomforest_on_reference.R
+++ b/utilities/rescue/run_randomforest_on_reference.R
@@ -73,10 +73,11 @@ message("\n\tPerforming ML filter data cleaning on classification...\n")
     NA_columns <- c("within_CAGE_peak", 'n_indels', "n_indels_junc", "FL",
                     "predicted_NMD", "min_sample_cov", "min_cov", "ratio_exp", "bite", 
                     "diff_to_gene_TSS", "diff_to_gene_TTS" , "dist_to_polyA_site", 
-                    "dist_to_CAGE_peak", 'within_polyA_site', "polyA_dist")
+                    "dist_to_CAGE_peak", 'within_polyA_site', "polyA_dist",
+                    "ratio_TSS")
     
     replacement.na <- c(0, 0, 0, 0, "non_coding",0, 0,0, FALSE, 
-                        -11000, -11000, -11000, -11000, FALSE, -11000)
+                        -11000, -11000, -11000, -11000, FALSE, -11000, 1)
     
     for (i in 1:length(NA_columns)) {
       sel.column <- which(colnames (classification) == NA_columns [i])


### PR DESCRIPTION
Solves problem in SQANTI3 ML Rescue (see #327).

The script to run pre-trained ML classifier on reference transcriptome lacks NA replacement value for ratio_TSS. Updated to match the ML filter script (NAs will now be replaced with a value of 1).