### PR TITLE
Modify write_collapsed_GFF_with_CDS in sqanti3_qc.py

### DIFF
--- a/sqanti3_qc.py
+++ b/sqanti3_qc.py
@@ -417,10 +417,11 @@ def write_collapsed_GFF_with_CDS(isoforms_info, input_gff, output_gff):
                     s, e = e, s
                     s = s - 1 # make it 0-based
                 for i,exon in enumerate(r.ref_exons):
-                    if exon.end > s: break
-                r.cds_exons = [Interval(s, min(e,exon.end))]
-                for exon in r.ref_exons[i+1:]:
-                    if exon.start > e: break
+                    if s >= min(e,exon.end): break
+                if s < min(e,exon.end):
+                  r.cds_exons = [Interval(s, min(e,exon.end))]
+                  for exon in r.ref_exons[i+1:]:
+                    if exon.start >= min(e, exon.end): break
                     r.cds_exons.append(Interval(exon.start, min(e, exon.end)))
             write_collapseGFF_format(f, r)
 


### PR DESCRIPTION
Suggestion to modify `if ...:break` statements in `write_collapsed_GFF_with_CDS` which compare interval start and end coordinates to ensure calls to `Interval()` do not throw `AssertionError: start must be less than end`. Current statements do not necessarily ensure that values given to `Interval()` are appropriate, for example, if exon coordinates are outside the predicted CDS start and end coordinates. 

Context: running SQANTI3 with GTF produced by [bambu](https://github.com/GoekeLab/bambu) was exiting with this error after classifying isoforms:

```
Traceback (most recent call last):
  File "sqanti3_qc.py", line 2578, in <module>
    main()
  File "sqanti3_qc.py", line 2561, in main
    run(args)
  File "sqanti3_qc.py", line 1880, in run
    write_collapsed_GFF_with_CDS(isoforms_info, corrGTF, corrGTF+'.cds.gff')
  File "sqanti3_qc.py", line 420, in write_collapsed_GFF_with_CDS
    r.cds_exons = [Interval(s, min(e,exon.end))]
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "lib/bx/intervals/intersection.pyx", line 293, in bx.intervals.intersection.Interval.__init__
AssertionError: start must be less than end
```