### PR TITLE
changed the input gtf to output introns to the corrected cds gff

### DIFF
--- a/sqanti_reads.py
+++ b/sqanti_reads.py
@@ -128,7 +128,7 @@ def make_UJC_hash(args, df):
         print("**** Calculating UJCs...", file = sys.stdout)
                 
         ## Take the corrected GTF
-        introns_cmd = f"""gtftools -i {outputPathPrefix}tmp_introns.bed -c "$(cut -f 1 {outputPathPrefix}_corrected.gtf | sort | uniq | paste -sd ',' - | sed 's/chr//g')" {outputPathPrefix}_corrected.gtf"""
+        introns_cmd = f"""gtftools -i {outputPathPrefix}tmp_introns.bed -c "$(cut -f 1 {outputPathPrefix}_corrected.gtf.cds.gff | sort | uniq | paste -sd ',' - | sed 's/chr//g')" {outputPathPrefix}_corrected.gtf.cds.gff"""
         ujc_cmd = f"""awk -F'\t' -v OFS="\t" '{{print $5,"chr"$1,$4,$2+1"_"$3}}' {outputPathPrefix}tmp_introns.bed | bedtools groupby -g 1 -c 2,3,4 -o distinct,distinct,collapse | sed 's/,/_/g' | awk -F'\t' -v OFS="\t" '{{print $1,$2"_"$3"_"$4}}' > {outputPathPrefix}tmp_UJC.txt"""
             
         if subprocess.check_call(introns_cmd, shell=True)!=0:


### PR DESCRIPTION
Changed the input gtf to output introns during the making of UJCs to the corrected cds gff due to incompatibilites with gtftools when running SQANTI3 with a fastq. Gtftools needs the exon lines from the gtf to have the "gene_id" flag, but this flag is not added to the corrected.gtf when the mapping step is run internally by SQANTI3. Using the cds version of the corrected gtf solves this. 