### PR TITLE
SR_bam now parses bam files directly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -146,6 +146,7 @@ example/SQANTI3_output/STAR_index/SAindex
 /example/run_sqanti3_pablo.sh
 sqanti_qc.out
 /pablo_tests
+/wiki
 
 # BugFixes
 /bugfix

--- a/src/argparse_utils.py
+++ b/src/argparse_utils.py
@@ -84,6 +84,17 @@ def valid_gff3(filename):
         sys.exit(1)
     return filename
 
+def valid_sr(filename):
+    if not os.path.isdir(filename):
+        if not filename.endswith('.fofn') and not filename.endswith('.bam'):
+            print(f"ERROR: File {filename} is not a BAM file, a directory, or a FOFN file. Abort!", file=sys.stderr)
+            sys.exit(1)
+        else:
+            if not os.path.isfile(filename):
+                print(f"ERROR: File {filename} not found. Abort!", file=sys.stderr)
+                sys.exit(1)
+    return filename
+
 ### Validation for the arguments
 
 def args_validation(args):

--- a/src/classification_preprocessing.py
+++ b/src/classification_preprocessing.py
@@ -56,7 +56,10 @@ def TSS_ratio_calculation(SR_bam,short_reads,star_out,star_index,corrGTF,ratio_T
     ## TSS ratio calculation
     if  SR_bam is not None:
         print("Using provided BAM files for calculating TSS ratio", file=sys.stdout)
-        bams = get_files_from_dir(SR_bam,".bam")
+        if SR_bam.endswith('.bam'):
+            bams = [SR_bam]
+        else:
+            bams = get_files_from_dir(SR_bam,".bam")
 
         # TODO: where did this functions come from?
         chr_order = get_bam_header(bams[0])

--- a/src/qc_argparse.py
+++ b/src/qc_argparse.py
@@ -18,7 +18,7 @@ def qc_argparse():
     apc.add_argument('--fasta', action='store_true', help='Use when running SQANTI by using as input a FASTA/FASTQ with the sequences of isoforms')
     apc.add_argument('--genename', action='store_true' ,help='Use gene_name tag from GTF to define genes. Default: gene_id used to define genes',)
     apc.add_argument('--short_reads', type=valid_file, help='File Of File Names (fofn, space separated) with paths to FASTA or FASTQ from Short-Read RNA-Seq. If expression or coverage files are not provided, Kallisto (just for pair-end data) and STAR, respectively, will be run to calculate them.')
-    apc.add_argument('--SR_bam' , help=' Directory or fofn file with the sorted bam files of Short Reads RNA-Seq mapped against the genome')
+    apc.add_argument('--SR_bam', type=valid_sr, help=' Directory or fofn file with the sorted bam files of Short Reads RNA-Seq mapped against the genome')
     apc.add_argument('--novel_gene_prefix', default=None, help='Prefix for novel isoforms (default: None)')
     # Aligner and mapping options
     apa = ap.add_argument_group("Aligner and mapping options")


### PR DESCRIPTION
This is a bug fix for the issue [381](https://github.com/ConesaLab/SQANTI3/issues/381), and now a single bam file can be given directly, and SQANTI3 will validate the input given to SR_bam argument