### PR TITLE
Updated the isoform sorting to accept a wider nomenclature

### DIFF
--- a/src/classification_main.py
+++ b/src/classification_main.py
@@ -7,6 +7,7 @@ from .classification_steps import (
     process_cage_peak_info, process_polya_peak_info,
     write_junction_info
 ) # type: ignore
+from .utils import alphanum_key
 from .config import  FIELDS_CLASS
 
 
@@ -68,7 +69,8 @@ def isoform_classification_pipeline(
     # Sort isoforms_info by the chromosome and then id.
     # Take into account that the ID is a string with numbers
 
-    iso_keys = sorted(isoforms_info.keys(), key=lambda x: (isoforms_info[x].chrom, int(isoforms_info[x].id.split('.')[1])))
+    iso_keys = sorted(isoforms_info.keys(), key=lambda x: (alphanum_key(isoforms_info[x].chrom),
+                                                           alphanum_key(isoforms_info[x].id)))
     isoforms_info = {key: isoforms_info[key] for key in iso_keys}
     
     handle_class.close()

--- a/src/parsers.py
+++ b/src/parsers.py
@@ -110,7 +110,6 @@ def isoforms_parser(queryFile):
     Parse input isoforms (GTF) to dict (chr --> sorted list)
     """
     print("**** Parsing Isoforms....", file=sys.stderr)
-    
     isoforms_list = defaultdict(lambda: []) # chr --> list to be sorted later
 
     for r in genePredReader(queryFile):

--- a/src/utils.py
+++ b/src/utils.py
@@ -3,6 +3,7 @@ import bisect
 from collections.abc import Iterable
 import math
 import os
+import re
 
 def mergeDict(dict1, dict2):
     """ Merge dictionaries to collect info from several files"""
@@ -82,3 +83,6 @@ def find_closest_in_list(lst, pos):
         a, b = lst[i-1]-pos, lst[i]-pos
         if abs(a) < abs(b): return a
         else: return b
+    
+def alphanum_key(s):
+    return [int(c) if c.isdigit() else c.lower() for c in re.split(r'(\d+)', s)]


### PR DESCRIPTION
This fixes a previous issue that caused an error if the isoforms name did not have a ".". This fixes the second error posted in the issue [379](https://github.com/ConesaLab/SQANTI3/issues/379)