### PR TITLE
Updated the fl count parser to accept floats in single samples

### DIFF
--- a/src/parsers.py
+++ b/src/parsers.py
@@ -310,7 +310,10 @@ def FLcount_parser(fl_count_filename):
 
     if flag_single_sample: # single sample
         for k,v in d.items():
-            fl_count_dict[k] = int(v['count_fl'])
+            try:
+                fl_count_dict[k] = int(v['count_fl'])
+            except ValueError:
+                fl_count_dict[k] = float(v['count_fl'])
     else: # multi-sample
         for k,v in d.items():
             fl_count_dict[k] = {}


### PR DESCRIPTION
There was a small error where if the fl file given was of a single sample, and the values were not integers, it would raise an error. This has been updated to also accept floats