### PR TITLE
Github actions: test docker build each commit, and publish to dockerhub on release

### DIFF
--- a/.github/workflows/generate-docker-image.yml
+++ b/.github/workflows/generate-docker-image.yml
@@ -1,0 +1,18 @@
+name: Docker Image CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Build the Docker image
+      run: docker build . --file Dockerfile --tag sqanti3:$(date +%s)

--- a/.github/workflows/push-to-dockerhub-on-release.yml
+++ b/.github/workflows/push-to-dockerhub-on-release.yml
@@ -1,0 +1,24 @@
+## Adapted from https://medium.com/@jaredhatfield/publishing-semantic-versioned-docker-images-to-github-packages-using-github-actions-ebe88fa74522
+## and https://github.com/docker/build-push-action
+name: Docker autogenerate and push to DockerHub when a new release is published
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build-and-push-docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_HUB_USER }}
+          password: ${{ secrets.DOCKER_HUB_USER_PASSWORD }}
+      - name: Set up Docker builder
+        uses: docker/setup-buildx-action@v3
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          push: true
+          tags: ${{ secrets.DOCKER_HUB_USER }}/sqanti3:latest, ${{ secrets.DOCKER_HUB_USER }}/sqanti3:${{ github.event.release.tag_name }}


### PR DESCRIPTION
2 new github actions are added:
- generate-docker-image.yml tests that the docker image can be build
- push-to-docker-hub-on-release.yml pushes the docker image to dockerhub on release, tagging latest and the current tag that is published