### PR TITLE
Bugfix/automatic rescue

### DIFF
--- a/sqanti3_rescue.py
+++ b/sqanti3_rescue.py
@@ -117,7 +117,7 @@ def main():
     
     rescue_gtf, inclusion_df, \
       counts, rescued_table = sq_requant.parse_files(rescue_gtf_path,inclusion_file,
-                                                     args.counts, prefix)
+                                                     args.counts, prefix,args.mode)
 
     sq_requant.run_requant(rescue_gtf, inclusion_df, counts, 
                            rescued_table, prefix)

--- a/src/utilities/rescue/automatic_rescue.py
+++ b/src/utilities/rescue/automatic_rescue.py
@@ -69,23 +69,22 @@ def save_automatic_rescue(rescue_df,class_df,mode,prefix):
         index=False
     )
 
-    if mode == 'automatic':
-        if rescue_df.iloc[0,0] == "none":
-            rescue_logger.info("No FSM mono-exonic artifacts found for automatic rescue.")
-        else:
-            # Second write operation: rescue_table with headers 
-            rescue_table = class_df[
-                class_df['associated_transcript'].isin(rescue_df['isoform'])
-            ][['isoform', 'associated_transcript', 'structural_category']].rename(
-                columns={
-                    'isoform': 'artifact',
-                    'associated_transcript': 'rescued_transcript'
-                }
-            )
+    if rescue_df.iloc[0,0] == "none":
+        rescue_logger.info("No FSM mono-exonic artifacts found for automatic rescue.")
+    else:
+        # Second write operation: rescue_table with headers 
+        rescue_table = class_df[
+            class_df['associated_transcript'].isin(rescue_df['isoform'])
+        ][['isoform', 'associated_transcript', 'structural_category']].rename(
+            columns={
+                'isoform': 'artifact',
+                'associated_transcript': 'rescued_transcript'
+            }
+        )
 
-            rescue_table.to_csv(
-                f"{prefix}_automatic_rescue_table.tsv",
-                sep='\t',
-                index=False
-            )
+        rescue_table.to_csv(
+            f"{prefix}_automatic_rescue_table.tsv",
+            sep='\t',
+            index=False
+        )
 

--- a/src/utilities/rescue/rescue_by_mapping_ML.R
+++ b/src/utilities/rescue/rescue_by_mapping_ML.R
@@ -75,18 +75,15 @@ opt$threshold <- as.numeric(opt$threshold)
     
     # add ML probabilities of mapping hits to mapping hits table
     mapping_hits <- mapping_hits %>% 
-      dplyr::left_join(probs %>% 
-                         dplyr::rename(mapping_hit = "isoform"), 
-                by = "mapping_hit") %>% 
+      dplyr::left_join(probs, 
+                by = c("mapping_hit" = "isoform")) %>% 
       dplyr::rename(hit_POS_MLprob = "POS_MLprob")
 
     # add structural categories of candidates to mapping hits table
     mapping_hits <- mapping_hits %>% 
-      dplyr::rename(isoform = "rescue_candidate") %>% 
       dplyr::left_join(classif %>% 
                          dplyr::select(isoform, structural_category), 
-                       by = "isoform") %>% 
-      dplyr::rename(rescue_candidate = "isoform") %>% 
+                       by = c("rescue_candidate" = "isoform")) %>% 
       dplyr::rename(candidate_structural_category = "structural_category")
     
   
@@ -121,13 +118,13 @@ opt$threshold <- as.numeric(opt$threshold)
       # include those that were retrieved in automatic rescue
       automatic_ref_rescued <- readr::read_tsv(paste0(opt$dir, "/", opt$output, 
                                                       "_automatic_inclusion_list.tsv"),
-                                               col_names = "associated_transcript") 
+                                               col_names = "associated_transcript")
       # Add empty row to avoid error when no automatic rescue is performed
       if (nrow(automatic_ref_rescued) == 0) {
         automatic_ref_rescued[1,"associated_transcript"] <- "none"
       }
       isoform_assoc.tr <- dplyr::bind_rows(isoform_assoc.tr, 
-                                           automatic_ref_rescued) %>% unique
+                                           automatic_ref_rescued) %>% unique()
       
       # find truly rescued references (not represented by any isoform)
       rescued_mapping_final <- rescued_ref %>% 
@@ -158,16 +155,17 @@ opt$threshold <- as.numeric(opt$threshold)
       
           # find FSM rescued during automatic rescue to add to rescue table
           automatic_fsm <- classif %>% 
-            dplyr::select(isoform, associated_transcript, 
-                          structural_category) %>% 
-            dplyr::right_join(automatic_ref_rescued %>% dplyr::rename(associated_transcript = "ref_transcript"), 
-                              by = "associated_transcript")
-          
+          dplyr::filter(associated_transcript %in% automatic_ref_rescued$ref_transcript &
+                          filter_result == "Artifact") %>%
+            dplyr::select(isoform, associated_transcript,
+                          structural_category) 
+            
+
           # add ML probabilities for automatic rescued references
           # and add SAM flag, rescue_result and exclusion_reason columns
           automatic_fsm <- automatic_fsm %>% 
-            dplyr::left_join(probs.ref %>% dplyr::rename(associated_transcript = "isoform"), 
-                                                          by = "associated_transcript") %>% 
+            dplyr::left_join(probs.ref, 
+                             by = c("associated_transcript" = "isoform")) %>% 
             dplyr::mutate(sam_flag = NA, 
                           rescue_result = "rescued_automatic", 
                           exclusion_reason = NA)

--- a/src/utilities/rescue/rescue_by_mapping_ML.R
+++ b/src/utilities/rescue/rescue_by_mapping_ML.R
@@ -305,4 +305,4 @@ opt$threshold <- as.numeric(opt$threshold)
       # output rescue table
       readr::write_tsv(rescue_table,
                        file = paste0(opt$dir, "/", opt$output, 
-                                     "_rescue_table.tsv"))
+                                     "_full_rescue_table.tsv"))

--- a/src/utilities/rescue/rescue_by_mapping_rules.R
+++ b/src/utilities/rescue/rescue_by_mapping_rules.R
@@ -281,9 +281,11 @@ rescue_table <- rescue_table %>%
       mutate(best_match_id = if_else(rescue_result == "rescued_automatic",
                                                     true = mapping_hit,
                                                     false = best_match_id))
-
-# output rescue table
+rescue_table <- rescue_table %>% 
+          dplyr::left_join(classif %>% dplyr::select(isoform, associated_gene),
+                           by = c("rescue_candidate" = "isoform")) 
+      # output rescue table
 write_tsv(rescue_table,
                   file = paste0(opt$dir, "/", opt$output,
-                                "_rescue_table.tsv"))
+                                "_full_rescue_table.tsv"))
 

--- a/src/utilities/rescue/rescue_by_mapping_rules.R
+++ b/src/utilities/rescue/rescue_by_mapping_rules.R
@@ -144,25 +144,26 @@ write_tsv(rescued_final,
 
 # find FSM rescued during automatic rescue to add to rescue table
 automatic_fsm <- classif %>%
+  dplyr::filter(associated_transcript %in% automatic_ref_rescued$ref_transcript &
+                  filter_result == "Artifact") %>%
   select(isoform, associated_transcript,
                 structural_category) %>%
-  right_join(automatic_ref_rescued %>% rename(associated_transcript = "ref_transcript"),
-                    by = "associated_transcript") %>%
 # add rules result for automatic rescued references
-  left_join(rules.ref %>% rename(associated_transcript = "isoform"),
-                    by = "associated_transcript") %>%
+  left_join(rules.ref,
+                    by = c("associated_transcript" = "isoform")) %>%
   # and add SAM flag, rescue_result and exclusion_reason columns
   mutate(sam_flag = NA,
                 rescue_result = "rescued_automatic",
                 exclusion_reason = NA) %>%
 # reorder and rename
   rename(rescue_candidate = "isoform",
-                mapping_hit = "associated_transcript",
-                hit_filter_result = "filter_result",
-                candidate_structural_category = "structural_category") %>%
+          mapping_hit = "associated_transcript",
+          hit_filter_result = "filter_result",
+          candidate_structural_category = "structural_category") %>%
   relocate(sam_flag, .after = rescue_candidate) %>%
   relocate(hit_filter_result, .after = mapping_hit)
 
+print(paste0("Automatic rescue: ", nrow(automatic_fsm), " transcripts rescued."))
 
 # include final rescue result in mapping hits table
 rescue_table <- mapping_hits %>%

--- a/src/utilities/rescue/sq_requant.py
+++ b/src/utilities/rescue/sq_requant.py
@@ -5,7 +5,7 @@ import sys
 import warnings
 warnings.filterwarnings("ignore")
 
-def parse_files(gtf_path,inclusion_file,count_file,prefix):
+def parse_files(gtf_path,inclusion_file,count_file,prefix,mode):
 
     col_names = [
         "Chromosome", "Source", "Feature", "Start", "End", "Score", "Strand", "Frame", "Attribute"
@@ -28,7 +28,7 @@ def parse_files(gtf_path,inclusion_file,count_file,prefix):
     counts.columns = ['transcript_id', 'count']
 
     #Rescued table
-    rescued_path=f"{prefix}_rescue_table.tsv"
+    rescued_path=f"{prefix}_{mode}_rescue_table.tsv"
     rescued_table = pd.read_csv(rescued_path, sep = '\t')
 
 


### PR DESCRIPTION
Small fix to a bug that was causing the ISM isoforms that had passed the filter, but whose associated transcript was being rescued to be included as rescue candidates in the full rescue table. This was increasing the counts, as they were included twice in the requantification: as true isoforms and as rescue candidates.