### PR TITLE
Fix custom TP/TN sets and remove_columns

### DIFF
--- a/src/filter_steps.py
+++ b/src/filter_steps.py
@@ -62,11 +62,11 @@ def prepare_ml_cmd(sq_class,prefix,outdir,percent_training,threshold,intraprimin
         -z {max_class_size}"
 
     if TP is not None:
-        cmd + f" -p {TP}"
+        cmd += f" --TP {TP}"
     if TN is not None:
-        cmd + f" -n {TN}"
+        cmd += f" --TN {TN}"
     if remove_columns is not None:
-        cmd + f" -r {remove_columns}"
+        cmd += f" --remove_columns {remove_columns}"
     return cmd
 
 # TODO: These two functions are almost the same. There should be some way around to merge them ;)


### PR DESCRIPTION
The -p, -n, -r parameters were not correctly added to the command. Furthermore, "-p" seemed to overload another parameter that lead to a warning, so it was changed to the longform "--TP" (and "--TN", "--remove_columns" for consistency)