### PR TITLE
Added multiple user input checks

### DIFF
--- a/src/argparse_utils.py
+++ b/src/argparse_utils.py
@@ -102,6 +102,13 @@ def valid_sr(filename,logger):
                 sys.exit(1)
     return filename
 
+def contains_gene_name(filepath):
+    with open(filepath, 'r') as f:
+        for line in f:
+            if 'gene_name' in line:
+                return True
+    return False
+
 ### Validation for the arguments
 
 def qc_args_validation(args):
@@ -160,6 +167,14 @@ def qc_args_validation(args):
 
     if args.gff3 is not None:
         valid_gff3(args.gff3,qc_logger)
+
+    # Check for gene_name attribute in GTF
+    if args.isoAnnotLite or args.genename:
+        if not contains_gene_name(args.isoforms):
+            option = "--isoAnnotLite" if args.isoAnnotLite else "--genename"
+            qc_logger.error("The 'gene_name' tag was not found in the input GTF file. SQANTI3 requires this tag to function properly.")
+            qc_logger.error(f"Please include the 'gene_name' tag in the GTF, or omit the {option} option.")
+            sys.exit(1)
 
 
     # Fusion isoforms checks

--- a/src/wrapper_utils.py
+++ b/src/wrapper_utils.py
@@ -58,6 +58,13 @@ def get_user_options(options, sqanti_options):
         key, value = option.split('=')
         if key not in sqanti_options:
             main_logger.warning(f"Option '{key}' not found in the default configuration.")
+            main_logger.warning("Would you like to continue? (y/n)")
+            answer = input().strip().lower()
+            if answer != 'y':
+                main_logger.error("Aborting...")
+                sys.exit(1)
+            else:
+                continue
             continue
         # Try to convert the value to an integer or float
         if value.isdigit():


### PR DESCRIPTION
Now, two more checks have been introduced in SQANTI3 qc:

1. In case the flags `--genename` or `--isoAnnotLite` are used, an error will be raised if no gene_name tag is in the input GTF attributes
2. A better warning is included in case the user includes a customized option via the `-a` flag in the wrapper