### PR TITLE
Fix argument validation bug and improve tests

### DIFF
--- a/src/argparse_utils.py
+++ b/src/argparse_utils.py
@@ -22,7 +22,7 @@ def valid_fasta(filename,logger):
 def valid_gtf(filename,logger):
     valid_file(filename,logger)
     if not filename.endswith('.gtf'):
-        if not filename.endswith('.gff') or not filename.endswith('.gff3'):
+        if not (filename.endswith('.gff') or filename.endswith('.gff3')):
             qc_logger.error(f"File {filename} is not a GTF file. Abort!")
             sys.exit(1)
         else:
@@ -115,7 +115,7 @@ def qc_args_validation(args):
         qc_logger.error("Input isoforms must be in GTF, FASTA, or FASTQ format. Abort!")
         sys.exit(1)
     
-    valid_gtf(args.refGTF,qc_logger)
+    args.refGTF = valid_gtf(args.refGTF,qc_logger)
     valid_fasta(args.refFasta,qc_logger)
 
     # Customization validation
@@ -201,7 +201,7 @@ def filter_args_validation(args):
     if args.filter_isoforms is not None:
         valid_fasta(args.filter_isoforms, filter_logger)
     if args.filter_gtf is not None:
-        valid_gtf(args.filter_gtf, filter_logger)
+        args.filter_gtf = valid_gtf(args.filter_gtf, filter_logger)
     if args.filter_sam is not None:
         valid_file(args.filter_sam, filter_logger)
     if args.filter_faa is not None:
@@ -233,12 +233,12 @@ def filter_args_validation(args):
 def rescue_args_validation(args):
     valid_file(args.filter_class, rescue_logger)
     valid_dir(args.dir,rescue_logger)
-    valid_gtf(args.refGTF,rescue_logger)
+    args.refGTF = valid_gtf(args.refGTF,rescue_logger)
     valid_fasta(args.refFasta,rescue_logger)
     if args.rescue_isoforms is not None:
         valid_fasta(args.rescue_isoforms,rescue_logger)
     if args.rescue_gtf is not None:
-        valid_gtf(args.rescue_gtf,rescue_logger)
+        args.rescue_gtf = valid_gtf(args.rescue_gtf,rescue_logger)
     if args.mode == "full":
         try:
             valid_file(args.refClassif,rescue_logger)

--- a/src/utils.py
+++ b/src/utils.py
@@ -91,7 +91,7 @@ def alphanum_key(s):
 def calculate_tss(strand, start0, end1):
     """
     Strand aware calculation of the middle of the peak in the bed file
-    If the cage peak length is of 1 nucleotide, the average is not calculcated
+    If the cage peak length is of 1 nucleotide, the average is not calculated
     """
     if end1 - start0 > 1:
         tss0 = int((start0 + end1) / 2)

--- a/test/unit/test_parsers.py
+++ b/test/unit/test_parsers.py
@@ -113,7 +113,7 @@ def test_reference_parser_correctJunctionsChr(reference_parser_input):
     assert junctions_by_chr["chr22"]["da_pairs"]['+'][0] == (11066515, 11067984)
     assert junctions_by_chr["chr22"]["da_pairs"]['-'][0] == (10939423, 10940596)
 
-def test_reference_parserc_correctJunctionsGene(reference_parser_input):
+def test_reference_parser_correctJunctionsGene(reference_parser_input):
     _, _, _, junctions_by_gene, _ = reference_parser(*list(reference_parser_input.values()))
     assert len(junctions_by_gene.keys()) == 913
     assert len(junctions_by_gene["ENSG00000206195.11"]) == 11

--- a/test/unit/utilities/test_short_reads.py
+++ b/test/unit/utilities/test_short_reads.py
@@ -261,5 +261,5 @@ def test_get_ratio_TSS_mean(test_files):
 
     assert isinstance(result, dict)
     assert len(result) > 0  
-    assert abs(result["PB.103709.3"]["return_ratio"] - 1425.2574257425742 <= 0.01) # Ensure we got some results
+    assert abs(result["PB.103709.3"]["return_ratio"] - 1425.2574257425742) <= 0.01  # Ensure we got some results
     assert np.isnan(result["PB.103820.1"]["return_ratio"])


### PR DESCRIPTION
## Summary
- fix GTF validation logic and update callers
- correct docstring typo in utils
- rename parser test helper
- fix tolerance assertion in short reads ratio test

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'Bio')*

------
https://chatgpt.com/codex/tasks/task_e_684080d461f083248783846f1adebe9a