### PR TITLE
Bugfix/negative strand positions 493

### DIFF
--- a/src/filter_output.py
+++ b/src/filter_output.py
@@ -25,7 +25,7 @@ def filter_gtf(filename,prefix,ids_to_keep):
     with open(outputGTF, 'w') as f:
         for r in collapseGFFReader(filename):
             # Fix negative strand coordinates
-            if (r.strand == '-') & (len(r.ref_exons) > 0): 
+            if (r.strand == '-') and (len(r.ref_exons) > 0): 
                 r.ref_exons.reverse()
                 r.start , r.end = r.ref_exons[0].start, r.ref_exons[-1].end # Positions get shifted by 1
             if r.seqid in ids_to_keep:

--- a/src/filter_output.py
+++ b/src/filter_output.py
@@ -25,7 +25,7 @@ def filter_gtf(filename,prefix,ids_to_keep):
     with open(outputGTF, 'w') as f:
         for r in collapseGFFReader(filename):
             # Fix negative strand coordinates
-            if r.strand == '-' & len(r.ref_exons) > 0: 
+            if (r.strand == '-') & (len(r.ref_exons) > 0): 
                 r.ref_exons.reverse()
                 r.start , r.end = r.ref_exons[0].start, r.ref_exons[-1].end # Positions get shifted by 1
             if r.seqid in ids_to_keep:

--- a/src/filter_output.py
+++ b/src/filter_output.py
@@ -24,6 +24,10 @@ def filter_gtf(filename,prefix,ids_to_keep):
     outputGTF = prefix + '.filtered.gtf'
     with open(outputGTF, 'w') as f:
         for r in collapseGFFReader(filename):
+            # Fix negative strand coordinates
+            if r.strand == '-' & len(r.ref_exons) > 0: 
+                r.ref_exons.reverse()
+                r.start , r.end = r.ref_exons[0].start, r.ref_exons[-1].end # Positions get shifted by 1
             if r.seqid in ids_to_keep:
                 write_collapseGFF_format(f, r)
         filter_logger.info(f"Output written to: {f.name}")

--- a/src/parallel.py
+++ b/src/parallel.py
@@ -33,6 +33,7 @@ def split_input_run(args, outdir):
     else:
         os.makedirs(SPLIT_ROOT_DIR)
 
+    # TODO: Check here the effect of the strand when ussing collapseGFFReader
     if not args.fasta:
         try:
             recs = [r for r in collapseGFFReader(args.isoforms)]

--- a/src/parsers.py
+++ b/src/parsers.py
@@ -231,6 +231,10 @@ def get_fusion_component(fusion_gtf):
     """
     components = defaultdict(lambda: {})
     for r in collapseGFFReader(fusion_gtf):
+        # Fix negative strand coordinates
+        if r.strand == '-': 
+            r.start, r.end =  r.ref_exons[-1].start, r.ref_exons[0].end # Positions get shifted by 1
+            r.ref_exons.reverse() # Fix the reference exons 
         m = seqid_fusion.match(r.seqid)
         gene, iso = int(m.group(1)), int(m.group(2))
         components[gene][iso] = sum(e.end-e.start for e in r.ref_exons)

--- a/src/qc_output.py
+++ b/src/qc_output.py
@@ -33,7 +33,6 @@ def write_omitted_isoforms(isoforms_info, outdir,prefix,min_ref_len,is_fusion, f
     return isoforms_info
 
 def write_classification_output(isoforms_info, outputClassPath, fields_class_cur):
-     
     # iso_keys = sorted(isoforms_info.keys(), key=lambda x: (isoforms_info[x].chrom, isoforms_info[x].id))
     with open(outputClassPath, 'w') as h:
         fout_class = DictWriter(h, fieldnames=fields_class_cur, delimiter='\t')
@@ -112,8 +111,7 @@ def write_collapsed_GFF_with_CDS(isoforms_info, input_gff, output_gff):
             # Fix negative strand coordinates
             if r.strand == '-': 
                 r.start, r.end =  r.ref_exons[-1].start, r.ref_exons[0].end # Positions get shifted by 1
-                r.ref_exons.reverse()
-                # Fix the reference exons 
+                r.ref_exons.reverse() # Fix the reference exons 
             r.geneid = isoforms_info[r.seqid].geneName()  # set the gene name
             s = isoforms_info[r.seqid].CDS_genomic_start  # could be 'NA'
             e = isoforms_info[r.seqid].CDS_genomic_end    # could be 'NA'

--- a/src/rescue_output.py
+++ b/src/rescue_output.py
@@ -1,10 +1,5 @@
-import os
-
 import shutil
-
 from Bio import SeqIO
-
-from src.utilities.cupcake.io.GFF import collapseGFFReader, write_collapseGFF_format
 
 # GTF output
 # TODO: Perhaps fix the order of the - strand exons

--- a/src/utilities/cupcake/io/GFF.py
+++ b/src/utilities/cupcake/io/GFF.py
@@ -559,6 +559,7 @@ class pasaGFFReader(gmapGFFReader):
                 rec.add_exon(start1-1, end1, -2, -1, None)
 
 def write_collapseGFF_format(f, r):
+    
     f.write("{chr}\tPacBio\ttranscript\t{s}\t{e}\t.\t{strand}\t.\ttranscript_id \"{tid}\"; gene_id \"{gid}\";\n".format(chr=r.chr, s=r.start+1, e=r.end, strand=r.strand,gid=r.geneid, tid=r.seqid))
     for exon in r.ref_exons:
         f.write("{chr}\tPacBio\texon\t{s}\t{e}\t.\t{strand}\t.\ttranscript_id \"{tid}\"; gene_id \"{gid}\";\n".format(chr=r.chr, s=exon.start+1, e=exon.end, strand=r.strand, gid=r.geneid, tid=r.seqid))

--- a/src/utilities/filter/SQANTI3_MLfilter.R
+++ b/src/utilities/filter/SQANTI3_MLfilter.R
@@ -302,7 +302,7 @@ if(is.null(opt$TP) == TRUE && is.null(opt$TN) == TRUE ){
  
 # Create new classification table for ML data preparation
 d1 <- d
-nrow(d1)
+
 if (run_ML) {
   cat("\n-------------------------------------------------")
   cat("\n\tML DATA PREPARATION:")

--- a/src/utilities/filter/SQANTI3_MLfilter.R
+++ b/src/utilities/filter/SQANTI3_MLfilter.R
@@ -302,8 +302,7 @@ if(is.null(opt$TP) == TRUE && is.null(opt$TN) == TRUE ){
  
 # Create new classification table for ML data preparation
 d1 <- d
-
-
+nrow(d1)
 if (run_ML) {
   cat("\n-------------------------------------------------")
   cat("\n\tML DATA PREPARATION:")
@@ -363,12 +362,17 @@ if (run_ML) {
   
   r = as.vector(which(apply(d1, 2, function(x) (anyNA(x)))))
   if (length(r) > 0){d1 <- d1[, -r]}
-  
+
   # Removing columns with zero variance
   cat("\nRemoving variables with near-zero variance...")
   nzv = caret::nearZeroVar(d1)
+  # Check if structural_category is in the list of columns to be removed and take it out
+  if("structural_category" %in% colnames(d1)[nzv]){
+    nzv <- nzv[-which(colnames(d1)[nzv] == "structural_category")]
+  }
+  
   if(length(colnames(d1)[nzv]) != 0){
-    cat("\tRemoved columns: ")
+    cat("\nRemoved columns: \n")
     print(paste(colnames(d1)[nzv]))
     d1 = d1[,-nzv]
   } else {
@@ -383,13 +387,13 @@ if (run_ML) {
   highCorr <- caret::findCorrelation(descrCorr, cutoff = 0.9, verbose = TRUE, names=TRUE)
   cat("\n\tList of removed features: ")
   if(length(highCorr)>0){
-    cat(paste("\t", highCorr))
+    cat(paste("\n\t", highCorr))
     d1 = d1[, -which(colnames(d1) %in% highCorr)]
   } else {
     cat("\tNo features removed.")
   }
-  
-  # END  of ML data preparation 
+
+  # END  of ML data preparation
   ############################
   
   
@@ -406,7 +410,6 @@ if (run_ML) {
   # Remove mono-exon transcripts from training set
   dmult <- d1[which(d1$exons != 1), ]
   
-  
   # Subset pre-processed data table (dmult) to make training dataset
   trainingset <- rbind(dmult[Positive_set, ],
                         dmult[Negative_set, ])
@@ -418,11 +421,11 @@ if (run_ML) {
   
   
   # Select columns that are not informative for ML
-colRem_def <- c("chrom", "strand", "associated_gene", "associated_transcript",
-                "ref_length", "ref_exons", "ORF_length", "CDS_length", "CDS_start",
-                "CDS_end", "CDS_genomic_start", "CDS_genomic_end", "all_canonical",
-                "seq_A_downstream_TTS", "ORF_seq", "subcategory", "structural_category",
-                "polyA_motif")
+  colRem_def <- c("chrom", "strand", "associated_gene", "associated_transcript",
+                  "ref_length", "ref_exons", "ORF_length", "CDS_length", "CDS_start",
+                  "CDS_end", "CDS_genomic_start", "CDS_genomic_end", "all_canonical",
+                  "seq_A_downstream_TTS", "ORF_seq", "subcategory", "structural_category",
+                  "polyA_motif")
 
   
   # Add RM TP set columns to remove to defined list (if it has been previously created)
@@ -497,8 +500,8 @@ colRem_def <- c("chrom", "strand", "associated_gene", "associated_transcript",
     cat("\nTraining Random Forest Classifier...")
     cat("\n\t***Note: this can take up to several hours.")
     cat("\nPre-defined Random Forest parameters (supplied to caret::trainControl()):")
-    cat("\t - Downsampling in training set (sampling = 'down').")
-    cat("\t - 10x cross-validation (repeats = 10).\n")
+    cat("\n\t - Downsampling in training set (sampling = 'down').")
+    cat("\n\t - 10x cross-validation (repeats = 10).\n")
     
     ctrl <- caret::trainControl(method = "repeatedcv", repeats = 10,
                       classProbs = TRUE,
@@ -506,7 +509,7 @@ colRem_def <- c("chrom", "strand", "associated_gene", "associated_transcript",
                       savePredictions = TRUE, returnResamp = "all")
     
     set.seed(1)
-    
+
     randomforest <- caret::train(x = training, 
                                  y = as.factor(Class[inTraining]),
                                  method = "rf",
@@ -638,8 +641,8 @@ colRem_def <- c("chrom", "strand", "associated_gene", "associated_transcript",
   dev.off()
   
   cat("\nROC curves saved to testSet_ROC_curve.pdf file. Includes:")
-  cat("\t - ROC curve with unbalanced classes.")
-  cat("\t - ROC curve with balanced classes.")
+  cat("\n\t - ROC curve with unbalanced classes.")
+  cat("\n\t - ROC curve with balanced classes.")
   
   
   #################################
@@ -667,8 +670,7 @@ colRem_def <- c("chrom", "strand", "associated_gene", "associated_transcript",
                                         rownames(negatives)] <- "Negative"
   cat("\nRandom forest classification results:")
   print(table(classified.isoforms$ML_classifier))
-  
-  
+    
   ####################################
   ## Add monoexons back to dataset  ##
   ####################################
@@ -708,17 +710,16 @@ colRem_def <- c("chrom", "strand", "associated_gene", "associated_transcript",
 ####################################
 
 cat("\n-------------------------------------------------")
-cat("\nApplying intra-priming filter to our dataset.")
-
+cat("\nApplying intra-priming filter to our dataset...")
 # apply to all not FSM transcripts and to all mono-exons from all categories
-d1[,"intra_priming"] <- d1$perc_A_downstream_TTS > as.numeric(opt$intrapriming) & 
+d1$intra_priming <- d1$perc_A_downstream_TTS > as.numeric(opt$intrapriming) &
   # not FSM: always TRUE
   (d1$structural_category != "full-splice_match" |
      # FSM: only TRUE when mono-exon
      (d1$structural_category == "full-splice_match" & d1$exons == 1))
 
 
-cat("\nIntra-priming filtered transcripts:")
+cat("\nIntra-priming filtered transcripts:\n")
 print(table(d1$intra_priming))
 
 
@@ -808,6 +809,7 @@ print(table(d_out$filter_result))
 cat("\n-------------------------------------------------")
 cat("\nSQANTI3 ML filter finished successfully!")
 cat("\n-------------------------------------------------")
+cat("\n")
 
 
 ################################################

--- a/src/utilities/filter/SQANTI3_MLfilter.R
+++ b/src/utilities/filter/SQANTI3_MLfilter.R
@@ -712,7 +712,7 @@ if (run_ML) {
 cat("\n-------------------------------------------------")
 cat("\nApplying intra-priming filter to our dataset...")
 # apply to all not FSM transcripts and to all mono-exons from all categories
-d1$intra_priming <- d1$perc_A_downstream_TTS > as.numeric(opt$intrapriming) &
+d1[,"intra_priming"] <- d1$perc_A_downstream_TTS > as.numeric(opt$intrapriming) &
   # not FSM: always TRUE
   (d1$structural_category != "full-splice_match" |
      # FSM: only TRUE when mono-exon

--- a/src/utilities/report_filter/SQANTI3_filter_report.R
+++ b/src/utilities/report_filter/SQANTI3_filter_report.R
@@ -74,14 +74,14 @@ if(opt$filter_type == "ml"){
   
   which_classif <- stringr::str_detect(paths, "ML_result_classification")
   path_classif <- paths[which_classif]
+
   classif <- readr::read_tsv(path_classif, 
                              col_types = readr::cols(exons = readr::col_integer(),
                                                      ref_exons = readr::col_integer()))
-  
-  
+
   # Detect path and load variable importance table
   message("\nReading classifier variable importance table...")
-  
+
   which_imp <- stringr::str_detect(paths, "variable-importance_table")
   path_imp <- paths[which_imp]
   imp <- readr::read_tsv(path_imp, col_names = c("variable", "importance"))
@@ -394,8 +394,14 @@ fsm_redund.df <- fsm %>%
 
 
 # ism redundancy
-ism_before <- classif %>% 
-  dplyr::filter(structural_category == "ISM")
+if (length(classif$structural_category[classif$structural_category == "ISM"]) == 0){
+  message("\nNo ISM transcripts found in classification table.")
+  message("Skipping ISM redundancy plots.")
+  ism_redund <- NULL
+  comb_redund <- NULL
+} else {
+  ism_before <- classif %>% 
+    dplyr::filter(structural_category == "ISM")
 
 ism_after <- classif %>% 
   dplyr::filter(structural_category == "ISM" &
@@ -407,6 +413,7 @@ ism <- dplyr::bind_rows(list(Before = ism_before, After = ism_after),
                   forcats::fct_relevel(c("Before", "After"))) %>% 
   dplyr::select(isoform, associated_gene, associated_transcript, 
                 structural_category, filter)
+
 
 ism_redund.df <- ism %>% 
   dplyr::group_by(filter, associated_transcript) %>% 
@@ -455,7 +462,7 @@ comb_redund.df <- comb_fsm_ism %>%
           xlab("FSM+ISM per reference transcript") +
           ylab("Reference transcfript no.") +
           facet_grid(~filter)
-        
+}        
         
 
 #### END common filter plots ####


### PR DESCRIPTION
Double fix in SQANTI:

- Negative strand isoforms had their start and end positions not reaching the full length of the transcript, because the exons order was inverted. This has been fixed for filter and rescue outputs, in QC it was already taken care of
- In the ML learning filter, if there was little variance in the structural category column, it would be eliminated, causing downstream analysis errors. Also, checks for datasets with missing ISMs have been included