### PR TITLE
Filter report and reference length update

### DIFF
--- a/src/classification_classifiers.py
+++ b/src/classification_classifiers.py
@@ -375,6 +375,9 @@ def novelIsoformsKnownGenes(isoforms_hit, trec, junctions_by_chr, junctions_by_g
     # or tss_diff and tts_diff (always set to "NA" for non-FSM/ISM matches)
     
     isoforms_hit.transcripts = ["novel"]
+    isoforms_hit.refLen = "NA"
+    isoforms_hit.refExons = "NA"
+
     if len(ref_genes) == 1:
         # hits exactly one gene, must be either NIC or NNC
         ref_gene_junctions = junctions_by_gene[ref_genes[0]]


### PR DESCRIPTION
Fixing the filter report so no error are raised if any category or group is missing.
A small fix to eliminate the value of ref_length in the classification file for NIC and NNC isoforms