### PR TITLE
Conda arm64 bug

### DIFF
--- a/.github/workflows/build-test-conda.yml
+++ b/.github/workflows/build-test-conda.yml
@@ -16,7 +16,7 @@ jobs:
         shell: bash -l {0}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-13, macos-14]
+        os: [ubuntu-latest, macos-15-intel, macos-14]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout repository

--- a/.github/workflows/build-test-conda.yml
+++ b/.github/workflows/build-test-conda.yml
@@ -48,7 +48,7 @@ jobs:
       # --- END OF ADDED STEPS ---
 
       - name: Set CONDA_SUBDIR for macOS Intel packages
-        if: runner.os == 'macOS' && runner.arch == 'X64'
+        if: runner.os == 'macOS'
         run: echo "CONDA_SUBDIR=osx-64" >> $GITHUB_ENV
       - name: Setup Miniconda
         uses: conda-incubator/setup-miniconda@v3.1.1
@@ -59,7 +59,7 @@ jobs:
           auto-activate-base: false
 
       - name: Configure conda environment for Intel packages
-        if: runner.os == 'macOS' && runner.arch == 'X64'
+        if: runner.os == 'macOS'
         run: conda config --env --set subdir osx-64
 
       - name: List conda packages

--- a/.github/workflows/build-test-conda.yml
+++ b/.github/workflows/build-test-conda.yml
@@ -16,7 +16,7 @@ jobs:
         shell: bash -l {0}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-15-intel, macos-14]
+        os: [ubuntu-latest, macos-15-intel, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout repository

--- a/.github/workflows/build-test-conda.yml
+++ b/.github/workflows/build-test-conda.yml
@@ -16,7 +16,7 @@ jobs:
         shell: bash -l {0}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-13, macos-14]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout repository
@@ -48,7 +48,7 @@ jobs:
       # --- END OF ADDED STEPS ---
 
       - name: Set CONDA_SUBDIR for macOS Intel packages
-        if: runner.os == 'macOS'
+        if: runner.os == 'macOS' && runner.arch == 'X64'
         run: echo "CONDA_SUBDIR=osx-64" >> $GITHUB_ENV
       - name: Setup Miniconda
         uses: conda-incubator/setup-miniconda@v3.1.1
@@ -59,7 +59,7 @@ jobs:
           auto-activate-base: false
 
       - name: Configure conda environment for Intel packages
-        if: runner.os == 'macOS'
+        if: runner.os == 'macOS' && runner.arch == 'X64'
         run: conda config --env --set subdir osx-64
 
       - name: List conda packages

--- a/SQANTI3.conda_env.yml
+++ b/SQANTI3.conda_env.yml
@@ -41,8 +41,6 @@ dependencies:
   - kallisto>=0.48
   - minimap2>=2.28
   - star==2.7.11b
-  - slamem>=0.8.5
-  
   # R and Bioconductor - major version constraints
   - r>=4.3.3
   - r-biocmanager>=1.30
@@ -74,7 +72,6 @@ dependencies:
   
   # Bioconductor packages
   - bioconductor-noiseq>=2.46
-  - bioconductor-busparse>=1.16
   - bioconductor-gviz
   
   # System utilities

--- a/src/utilities/rescue/automatic_rescue.R
+++ b/src/utilities/rescue/automatic_rescue.R
@@ -311,13 +311,7 @@ if(opt$mode == "full"){
   # get targets from reference transcriptome
   cat("\n\t Finding target isoforms from reference transcriptome...\n")
   
-  reference_ids <- BUSpaRse::tr2g_gtf(opt$refGTF, 
-                                      gene_version = NULL,
-                                      get_transcriptome = FALSE, 
-                                      out_path = opt$dir, 
-                                      save_filtered_gtf = FALSE,
-                                      write_tr2g = FALSE,
-                                      chrs_only = FALSE)
+  reference_ids <- get_tr2g_gtf(opt$refGTF)
   
   rescue_targets.ref <- reference_ids %>% 
     dplyr::filter(gene %in% target_genes) %>% 

--- a/src/utilities/rescue/rescue_aux_functions.R
+++ b/src/utilities/rescue/rescue_aux_functions.R
@@ -21,3 +21,39 @@ rescue_lost_reference <- function(ref_id, classif){
     return(ism_df)
   }
 }
+
+# function to extract transcript and gene IDs from GTF
+# Replacement for BUSpaRse::tr2g_gtf that is not available on ARM64 Macs
+get_tr2g_gtf <- function(gtf_file) {
+  # Read GTF file
+  # GTF has 9 columns, no header
+  # Use readr::read_tsv for speed and convenience
+  gtf <- readr::read_tsv(gtf_file, col_names = FALSE, comment = "#", show_col_types = FALSE)
+  
+  # Filter for transcripts
+  # Column 3 is feature type
+  gtf_transcripts <- dplyr::filter(gtf, X3 == "transcript")
+  
+  if (nrow(gtf_transcripts) == 0) {
+    gtf_transcripts <- dplyr::filter(gtf, X3 == "exon")
+  }
+  
+  # Extract attributes from column 9 (X9)
+  attributes <- gtf_transcripts$X9
+  
+  # Extract gene_id and transcript_id using regex
+  # Assuming standard GTF format: gene_id "ID"; transcript_id "ID";
+  
+  gene_ids <- stringr::str_extract(attributes, 'gene_id "[^"]+"')
+  gene_ids <- stringr::str_remove(gene_ids, 'gene_id "')
+  gene_ids <- stringr::str_remove(gene_ids, '"')
+  
+  transcript_ids <- stringr::str_extract(attributes, 'transcript_id "[^"]+"')
+  transcript_ids <- stringr::str_remove(transcript_ids, 'transcript_id "')
+  transcript_ids <- stringr::str_remove(transcript_ids, '"')
+  
+  res <- data.frame(transcript = transcript_ids, gene = gene_ids, stringsAsFactors = FALSE)
+  res <- dplyr::distinct(res)
+  
+  return(res)
+}


### PR DESCRIPTION
Removed two conda dependencies that are not available for ARM64 (Apple Silicon) Macs: slamem and bioconductor-busparse.
slamem>=0.8.5 - was listed but never actually used in the codebase
Added replacement function for BUSpaRse in src/utilities/rescue/rescue_aux_functions.R:
New get_tr2g_gtf() function that extracts transcript-to-gene mappings from GTF files
Also updated CI/CD to run the conda environment check for both intel and apple silicon macs