### PR TITLE
Fix TUSCO wiki links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ For detailed documentation, please visit [the SQANTI3 wiki](https://github.com/C
 * [Running SQANTI3 from the wrapper](https://github.com/ConesaLab/SQANTI3/wiki/Running-SQANTI3-from-the-wrapper)
 
 * [Running SQANTI3 quality control](https://github.com/ConesaLab/SQANTI3/wiki/Running-SQANTI3-Quality-Control)
-* [TUSCO quick start (SQANTI3 QC)](https://github.com/ConesaLab/SQANTI3/wiki/TUSCO-quick-start)
+* [TUSCO quick start (SQANTI3 QC)](https://github.com/ConesaLab/SQANTI3/wiki/TUSCO-quick-start-(SQANTI3-QC))
+* [TUSCO-novel (Novel Isoform Stress Test)](https://github.com/ConesaLab/SQANTI3/wiki/TUSCO%E2%80%90novel-(Novel-Isoform-Stress-Test))
 
 * [Understanding the output of SQANTI3 QC](https://github.com/ConesaLab/SQANTI3/wiki/Understanding-the-output-of-SQANTI3-QC)
 


### PR DESCRIPTION
## Summary
- Fix broken TUSCO quick start wiki link: `TUSCO-quick-start` → `TUSCO-quick-start-(SQANTI3-QC)`
- Add missing TUSCO-novel wiki page link to README

The TUSCO quick start link was pointing to a non-existent wiki page slug, causing users to land on the wiki home page instead.

## Test plan
- [ ] Verify the TUSCO quick start link navigates to the correct wiki page
- [ ] Verify the TUSCO-novel link navigates to the correct wiki page

🤖 Generated with [Claude Code](https://claude.com/claude-code)