### PR TITLE
fix: rename ref_num_exons to ref_exons to match CSV fieldnames

### DIFF
--- a/src/classification_steps.py
+++ b/src/classification_steps.py
@@ -24,7 +24,7 @@ def classify_isoform(rec, refs_1exon_by_chr, refs_exons_by_chr, junctions_by_chr
 
         if isoform_hit.structural_category not in ("full-splice_match", "incomplete-splice_match"):
             isoform_hit.ref_length = None
-            isoform_hit.ref_num_exons = None
+            isoform_hit.ref_exons = None
 
 
         return isoform_hit


### PR DESCRIPTION
## Problem
sqanti3_qc.py` crashes with:
ValueError: dict contains fields not in fieldnames: 'ref_num_exons'

The isoform dict used `ref_num_exons` but the CSV header declares `ref_exons`.
Fixed by renaming the assignment in `src/classification_steps.py`.